### PR TITLE
Use https on cdn

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,7 @@
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
 
-    <link href="http://netdna.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://netdna.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" rel="stylesheet">
   </head>
 
   <body>
@@ -18,6 +18,6 @@
       <%= yield %>
     </div>
 
-    <script src="http://netdna.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js"></script>
+    <script src="https://netdna.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Subi o projeto para o Heroku mas os assets não carregaram. A causa do problema foi que carreguei o bootstrap via CDN e estava sem https, o chrome barrou a requisição.

De qualquer forma, segue a URL do heroku: https://alunos-da-obra-do-berco.herokuapp.com/